### PR TITLE
getElementById is failing in custom reports.

### DIFF
--- a/circles.js
+++ b/circles.js
@@ -67,8 +67,11 @@
                      },
 
   Circles = function(options) {
-    var elId = options.id;
-    this._el = document.getElementById(elId);
+    if (options.el) {
+      this._el = options.el;
+    } else {
+      this._el = document.getElementById(options.id);
+    }
 
     if (this._el === null) return;
 


### PR DESCRIPTION
Allow passing in an element as alternate way to initialize.
More specifically, when used within an iframe, getElementById fails for us. 